### PR TITLE
Refactor Dockerfile to use ECR ASP.NET+NewRelic base image

### DIFF
--- a/.github/workflows/aws_main-payment.yml
+++ b/.github/workflows/aws_main-payment.yml
@@ -57,7 +57,9 @@ jobs:
     # Build & Push da API
     - name: Build and push API image
       run: |
-        docker build -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
+        docker build --build-arg AWS_REGION=${{ vars.AWS_REGION }} \
+        --build-arg AWS_ACCOUNT_ID=${{ vars.AWS_ACCOUNT_ID }} \
+        -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
         docker tag ${{env.FCG_API_NAME}}:latest ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
         docker push ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
 

--- a/FCG.Payments.API/Dockerfile
+++ b/FCG.Payments.API/Dockerfile
@@ -1,4 +1,9 @@
-﻿# This stage is used to build the service project
+﻿# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+ARG AWS_ACCOUNT_ID
+ARG AWS_REGION
+ARG BASE_RUNTIME_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/aspnet-newrelic-runtime:latest
+
+# This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
@@ -11,66 +16,15 @@ COPY . .
 WORKDIR "/src/FCG.Payments.API"
 RUN dotnet build "./FCG.Payments.API.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
+
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./FCG.Payments.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./FCG.Paymnets.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# FINAL STAGE - Aqui fazemos tudo do zero
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
-# Mantém como root para instalação
-USER root
-
+# Stage final: usa a imagem do ECR com aspnet + new relic
+FROM ${BASE_RUNTIME_IMAGE} AS final
 WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
-
-# ============================================
-# INSTALAÇÃO DO NEW RELIC
-# ============================================
-RUN apt-get update && \
-    apt-get install -y wget ca-certificates gnupg && \
-    mkdir -p /usr/share/keyrings && \
-    wget -O- https://download.newrelic.com/548C16BF.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/newrelic-archive-keyring.gpg] http://apt.newrelic.com/debian/ newrelic non-free" > /etc/apt/sources.list.d/newrelic.list && \
-    apt-get update && \
-    apt-get install -y newrelic-dotnet-agent && \
-    rm -rf /var/lib/apt/lists/*
-
-# Verificar instalação (importante para debug)
-RUN echo "Verificando instalação do New Relic..." && \
-    ls -la /usr/local/newrelic-dotnet-agent/ && \
-    test -f /usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so && \
-    echo "✅ New Relic instalado com sucesso!" || \
-    (echo "❌ Falha na instalação do New Relic" && exit 1)
-
-# Ajustar permissões
-RUN chmod -R 755 /usr/local/newrelic-dotnet-agent
-
-# ============================================
-# CONFIGURAÇÃO DAS VARIÁVEIS DE AMBIENTE
-# ============================================
-ENV CORECLR_ENABLE_PROFILING=1 \
-    CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
-    CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
-    CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
-    NEW_RELIC_LICENSE_KEY=49fea977ae8cb8915399b2c027e24687FFFFNRAL \
-    NEW_RELIC_APP_NAME="fcg-payments-api" \
-    NEW_RELIC_LOG_LEVEL=debug
-
-# Copiar aplicação publicada
 COPY --from=publish /app/publish .
-
-# Opcional: Adicionar script de verificação ao iniciar
-RUN echo '#!/bin/bash\n\
-echo "=== New Relic Status ==="\n\
-echo "Profiler exists: $(test -f /usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so && echo YES || echo NO)"\n\
-echo "CORECLR_ENABLE_PROFILING: $CORECLR_ENABLE_PROFILING"\n\
-echo "CORECLR_PROFILER_PATH: $CORECLR_PROFILER_PATH"\n\
-echo "NEW_RELIC_APP_NAME: $NEW_RELIC_APP_NAME"\n\
-echo "========================"\n\
-exec dotnet FCG.Payments.API.dll' > /app/start.sh && \
-    chmod +x /app/start.sh
-
-ENTRYPOINT ["/app/start.sh"]
+ENTRYPOINT ["dotnet", "FCG.Payments.API.dll"]

--- a/k8s/payments-api-config.yaml
+++ b/k8s/payments-api-config.yaml
@@ -6,3 +6,4 @@ data:
   API__GamesApiBaseUrl: "http://a6587e70854324f0382892a6190a8249-321469658.us-east-1.elb.amazonaws.com"
   API__UsersApiBaseUrl: "http://a713a61616cf640cab8a8b32af674486-1121567036.us-east-1.elb.amazonaws.com"
   API__PaymentGatewayBaseUrl: "https://payment-gateway-hjgsdacahzdmazdc.canadacentral-01.azurewebsites.net"
+  NEW_RELIC_APP_NAME: "fcg-payments-api"


### PR DESCRIPTION
Refactor Dockerfile to use ECR ASP.NET+NewRelic base image

Replaces manual New Relic installation in the Dockerfile with a custom ASP.NET + New Relic runtime image from AWS ECR, using new build arguments for region and account. Updates the GitHub Actions workflow to pass these arguments during build. Simplifies the entrypoint and removes the custom start script. Adds NEW_RELIC_APP_NAME to the Kubernetes ConfigMap for easier configuration.